### PR TITLE
feat: configure lambda router via yaml

### DIFF
--- a/aws-lambda-router/README.md
+++ b/aws-lambda-router/README.md
@@ -1,5 +1,16 @@
 # aws-lambda-router
 
+## Compiling `cabiri-io/cosmo` for testing
+
+If you want to test out a new binary of `aws-lambda-router` during development, you can use:
+
+```
+cd aws-lambda-router
+GOOS=linux make build
+```
+
+This will generate `aws-lambda-router/bootstrap`, which can then be used in an AWS Lambda function using the `provided.al2` runtime.
+
 <p align="center">
 <img width="550" src="cover.png"/>
 </p>

--- a/aws-lambda-router/config.test-invalid.yaml
+++ b/aws-lambda-router/config.test-invalid.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../router/pkg/config/config.schema.json
+
+version: '1'
+
+invalid_field: 'invalid'

--- a/aws-lambda-router/config.test.yaml
+++ b/aws-lambda-router/config.test.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../../router/pkg/config/config.schema.json
+
+version: '1'
+
+authentication:
+  providers:
+    - name: Test Auth Service
+      jwks:
+        # Example JWKS - Google OIDC
+        url: https://www.googleapis.com/oauth2/v3/certs
+        refresh_interval: 5m
+headers:
+  all:
+    request:
+      - op: 'propagate'
+        matching: Authorization
+log_level: debug

--- a/aws-lambda-router/internal/router.go
+++ b/aws-lambda-router/internal/router.go
@@ -45,7 +45,8 @@ func NewRouter(opts ...Option) (*core.Router, error) {
 
 	routerConfig, err := execution_config.FromFile(rc.RouterConfigPath)
 	if err != nil {
-		logger.Fatal("Could not read execution config", zap.Error(err), zap.String("path", rc.RouterConfigPath))
+		logger.Error("Could not read execution config", zap.Error(err), zap.String("path", rc.RouterConfigPath))
+		return nil, err
 	}
 
 	routerOpts := []core.Option{
@@ -60,12 +61,15 @@ func NewRouter(opts ...Option) (*core.Router, error) {
 
 	configYaml, err := config.LoadConfig(rc.ConfigPath, "")
 	if err != nil {
-		logger.Fatal("Could not load config from YAML", zap.Error(err), zap.String("path", rc.ConfigPath))
+		logger.Error("Could not load config from YAML", zap.Error(err), zap.String("path", rc.ConfigPath))
+		return nil, err
 	}
 
 	if configYaml != nil {
 		logger.Info("Using configuration from config.yaml")
 		cfg := &configYaml.Config
+
+		// Supports same configuration options as router/cmd/instance.go:NewRouter
 
 		routerOpts = append(routerOpts,
 			core.WithListenerAddr(cfg.ListenAddr),
@@ -229,7 +233,8 @@ func NewRouter(opts ...Option) (*core.Router, error) {
 
 	r, err := core.NewRouter(append(rc.RouterOpts, routerOpts...)...)
 	if err != nil {
-		logger.Fatal("Could not create router", zap.Error(err))
+		logger.Error("Could not create router", zap.Error(err))
+		return nil, err
 	}
 
 	return r, nil

--- a/aws-lambda-router/internal/router.go
+++ b/aws-lambda-router/internal/router.go
@@ -1,9 +1,13 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/wundergraph/cosmo/router/core"
+	"github.com/wundergraph/cosmo/router/pkg/authentication"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+	"github.com/wundergraph/cosmo/router/pkg/cors"
 	"github.com/wundergraph/cosmo/router/pkg/execution_config"
 	"github.com/wundergraph/cosmo/router/pkg/metric"
 	"github.com/wundergraph/cosmo/router/pkg/trace"
@@ -13,6 +17,7 @@ import (
 type Option func(*RouterConfig)
 
 type RouterConfig struct {
+	ConfigPath           string
 	RouterConfigPath     string
 	TelemetryServiceName string
 	RouterOpts           []core.Option
@@ -24,8 +29,8 @@ type RouterConfig struct {
 	Logger               *zap.Logger
 }
 
-func NewRouter(opts ...Option) *core.Router {
-
+func NewRouter(opts ...Option) (*core.Router, error) {
+	ctx := context.Background()
 	rc := &RouterConfig{}
 
 	for _, opt := range opts {
@@ -51,6 +56,140 @@ func NewRouter(opts ...Option) *core.Router {
 		core.WithStaticExecutionConfig(routerConfig),
 		core.WithAwsLambdaRuntime(),
 		core.WithGraphApiToken(rc.GraphApiToken),
+	}
+
+	configYaml, err := config.LoadConfig(rc.ConfigPath, "")
+	if err != nil {
+		logger.Fatal("Could not load config from YAML", zap.Error(err), zap.String("path", rc.ConfigPath))
+	}
+
+	if configYaml != nil {
+		logger.Info("Using configuration from config.yaml")
+		cfg := &configYaml.Config
+
+		routerOpts = append(routerOpts,
+			core.WithListenerAddr(cfg.ListenAddr),
+			core.WithOverrideRoutingURL(cfg.OverrideRoutingURL),
+			core.WithOverrides(cfg.Overrides),
+			core.WithLogger(logger),
+			core.WithIntrospection(cfg.IntrospectionEnabled),
+			core.WithQueryPlans(cfg.QueryPlansEnabled),
+			core.WithPlayground(cfg.PlaygroundEnabled),
+			core.WithGraphApiToken(cfg.Graph.Token),
+			core.WithPersistedOperationsConfig(cfg.PersistedOperationsConfig),
+			core.WithAutomatedPersistedQueriesConfig(cfg.AutomaticPersistedQueries),
+			core.WithApolloCompatibilityFlagsConfig(cfg.ApolloCompatibilityFlags),
+			core.WithStorageProviders(cfg.StorageProviders),
+			core.WithGraphQLPath(cfg.GraphQLPath),
+			core.WithModulesConfig(cfg.Modules),
+			core.WithGracePeriod(cfg.GracePeriod),
+			core.WithPlaygroundPath(cfg.PlaygroundPath),
+			core.WithHealthCheckPath(cfg.HealthCheckPath),
+			core.WithLivenessCheckPath(cfg.LivenessCheckPath),
+			core.WithGraphQLMetrics(&core.GraphQLMetricsConfig{
+				Enabled:           cfg.GraphqlMetrics.Enabled,
+				CollectorEndpoint: cfg.GraphqlMetrics.CollectorEndpoint,
+			}),
+			core.WithAnonymization(&core.IPAnonymizationConfig{
+				Enabled: cfg.Compliance.AnonymizeIP.Enabled,
+				Method:  core.IPAnonymizationMethod(cfg.Compliance.AnonymizeIP.Method),
+			}),
+			core.WithClusterName(cfg.Cluster.Name),
+			core.WithInstanceID(cfg.InstanceID),
+			core.WithReadinessCheckPath(cfg.ReadinessCheckPath),
+			core.WithHeaderRules(cfg.Headers),
+			core.WithRouterTrafficConfig(&cfg.TrafficShaping.Router),
+			core.WithFileUploadConfig(&cfg.FileUpload),
+			core.WithSubgraphTransportOptions(core.NewSubgraphTransportOptions(cfg.TrafficShaping)),
+			core.WithSubgraphRetryOptions(
+				cfg.TrafficShaping.All.BackoffJitterRetry.Enabled,
+				cfg.TrafficShaping.All.BackoffJitterRetry.MaxAttempts,
+				cfg.TrafficShaping.All.BackoffJitterRetry.MaxDuration,
+				cfg.TrafficShaping.All.BackoffJitterRetry.Interval,
+			),
+			core.WithCors(&cors.Config{
+				Enabled:          cfg.CORS.Enabled,
+				AllowOrigins:     cfg.CORS.AllowOrigins,
+				AllowMethods:     cfg.CORS.AllowMethods,
+				AllowCredentials: cfg.CORS.AllowCredentials,
+				AllowHeaders:     cfg.CORS.AllowHeaders,
+				MaxAge:           cfg.CORS.MaxAge,
+			}),
+			core.WithTLSConfig(&core.TlsConfig{
+				Enabled:  cfg.TLS.Server.Enabled,
+				CertFile: cfg.TLS.Server.CertFile,
+				KeyFile:  cfg.TLS.Server.KeyFile,
+				ClientAuth: &core.TlsClientAuthConfig{
+					CertFile: cfg.TLS.Server.ClientAuth.CertFile,
+					Required: cfg.TLS.Server.ClientAuth.Required,
+				},
+			}),
+			core.WithDevelopmentMode(cfg.DevelopmentMode),
+			core.WithTracing(core.TraceConfigFromTelemetry(&cfg.Telemetry)),
+			core.WithMetrics(core.MetricConfigFromTelemetry(&cfg.Telemetry)),
+			core.WithTelemetryAttributes(cfg.Telemetry.Attributes),
+			core.WithEngineExecutionConfig(cfg.EngineExecutionConfiguration),
+			core.WithCacheControlPolicy(cfg.CacheControl),
+			core.WithSecurityConfig(cfg.SecurityConfiguration),
+			core.WithAuthorizationConfig(&cfg.Authorization),
+			core.WithWebSocketConfiguration(&cfg.WebSocket),
+			core.WithSubgraphErrorPropagation(cfg.SubgraphErrorPropagation),
+			core.WithLocalhostFallbackInsideDocker(cfg.LocalhostFallbackInsideDocker),
+			core.WithCDN(cfg.CDN),
+			core.WithEvents(cfg.Events),
+			core.WithRateLimitConfig(&cfg.RateLimit),
+			core.WithClientHeader(cfg.ClientHeader),
+			core.WithCacheWarmupConfig(&cfg.CacheWarmup),
+		)
+
+		var authenticators []authentication.Authenticator
+		for i, auth := range cfg.Authentication.Providers {
+			if auth.JWKS != nil {
+				name := auth.Name
+				if name == "" {
+					name = fmt.Sprintf("jwks-#%d", i)
+				}
+				providerLogger := logger.With(zap.String("provider_name", name))
+				tokenDecoder, err := authentication.NewJwksTokenDecoder(ctx, providerLogger, auth.JWKS.URL, auth.JWKS.RefreshInterval)
+				if err != nil {
+					providerLogger.Error("Could not create JWKS token decoder", zap.Error(err))
+					return nil, err
+				}
+				opts := authentication.HttpHeaderAuthenticatorOptions{
+					Name:                name,
+					URL:                 auth.JWKS.URL,
+					HeaderNames:         auth.JWKS.HeaderNames,
+					HeaderValuePrefixes: auth.JWKS.HeaderValuePrefixes,
+					TokenDecoder:        tokenDecoder,
+				}
+				authenticator, err := authentication.NewHttpHeaderAuthenticator(opts)
+				if err != nil {
+					providerLogger.Error("Could not create HttpHeader authenticator", zap.Error(err))
+					return nil, err
+				}
+				authenticators = append(authenticators, authenticator)
+
+				if cfg.WebSocket.Authentication.FromInitialPayload.Enabled {
+					opts := authentication.WebsocketInitialPayloadAuthenticatorOptions{
+						TokenDecoder:        tokenDecoder,
+						Key:                 cfg.WebSocket.Authentication.FromInitialPayload.Key,
+						HeaderValuePrefixes: auth.JWKS.HeaderValuePrefixes,
+					}
+					authenticator, err = authentication.NewWebsocketInitialPayloadAuthenticator(opts)
+					if err != nil {
+						providerLogger.Error("Could not create WebsocketInitialPayload authenticator", zap.Error(err))
+						return nil, err
+					}
+					authenticators = append(authenticators, authenticator)
+				}
+			}
+		}
+
+		if len(authenticators) > 0 {
+			routerOpts = append(routerOpts, core.WithAccessController(core.NewAccessController(authenticators, cfg.Authorization.RequireAuthentication)))
+		}
+	} else {
+		logger.Info("No configuration file found, skipping YAML-based configuration", zap.String("path", rc.ConfigPath))
 	}
 
 	if rc.HttpPort != "" {
@@ -93,7 +232,13 @@ func NewRouter(opts ...Option) *core.Router {
 		logger.Fatal("Could not create router", zap.Error(err))
 	}
 
-	return r
+	return r, nil
+}
+
+func WithConfigFilePath(path string) Option {
+	return func(r *RouterConfig) {
+		r.ConfigPath = path
+	}
 }
 
 func WithRouterConfigPath(path string) Option {

--- a/aws-lambda-router/internal/router_test.go
+++ b/aws-lambda-router/internal/router_test.go
@@ -38,3 +38,16 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, response)
 }
+
+func TestHandlerThrowsErrorWhenConfigFileIsInvalid(t *testing.T) {
+	logger, err := zap.NewProduction()
+	require.NoError(t, err)
+
+	r, err := NewRouter(
+		WithLogger(logger),
+		WithConfigFilePath("../config.test-invalid.yaml"),
+		WithRouterConfigPath("../router.json"),
+	)
+	require.Error(t, err)
+	require.Nil(t, r)
+}

--- a/aws-lambda-router/internal/router_test.go
+++ b/aws-lambda-router/internal/router_test.go
@@ -3,10 +3,11 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"testing"
+
 	"github.com/akrylysov/algnhsa"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
 )
@@ -15,8 +16,9 @@ func TestHandler(t *testing.T) {
 	logger, err := zap.NewProduction()
 	require.NoError(t, err)
 
-	r := NewRouter(
+	r, err := NewRouter(
 		WithLogger(logger),
+		WithConfigFilePath("../config.test.yaml"),
 		WithRouterConfigPath("../router.json"),
 	)
 	require.NoError(t, err)

--- a/aws-lambda-router/package.json
+++ b/aws-lambda-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Placeholder package to simplify versioning and releasing with lerna.",
   "keywords": [


### PR DESCRIPTION
Implements configuration via YAML for `aws-lambda-router`.

- Supports all the configuration options (including auth providers) as `router/cmd/instance.go:NewRouter`
- Configuration file path can be defined via `CONFIG_PATH` env var, by default looks at `config.yaml`
- Testing:
  - Basic test to prove configuration can be provided without erroring
  - Manually testing the new binary in Lambda handler configuration with authentication provider
    - Added docs on this approach
- Bumps version to `0.2.0`