### PR TITLE
feat: set subgraph req header from auth claims

### DIFF
--- a/aws-lambda-router/package.json
+++ b/aws-lambda-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-router",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Placeholder package to simplify versioning and releasing with lerna.",
   "keywords": [

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -357,7 +357,7 @@ func (h *HeaderPropagation) applyResponseRuleKeyValue(res *http.Response, propag
 
 func (h *HeaderPropagation) applyRequestRule(ctx RequestContext, request *http.Request, rule *config.RequestHeaderRule) {
 	if rule.Operation == config.HeaderRuleOperationSet {
-		if rule.ValueFrom != nil && rule.ValueFrom.ContextField != "" {
+		if rule.ValueFrom != nil && (rule.ValueFrom.ContextField != "" || rule.ValueFrom.AuthClaim != "") {
 			val := getCustomDynamicAttributeValue(rule.ValueFrom, getRequestContext(request.Context()), nil)
 			value := fmt.Sprintf("%v", val)
 			if value != "" {

--- a/router/core/header_rule_engine_test.go
+++ b/router/core/header_rule_engine_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router/pkg/authentication"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 
 	"github.com/stretchr/testify/assert"
@@ -865,4 +866,157 @@ func TestInvalidRegex(t *testing.T) {
 		},
 	})
 	assert.Error(t, err)
+}
+
+type testAuth struct {
+	authenticator string
+	claims        authentication.Claims
+}
+
+func (tA testAuth) Authenticator() string {
+	return tA.authenticator
+}
+
+func (tA testAuth) Claims() authentication.Claims {
+	return tA.claims
+}
+
+func (tA testAuth) Scopes() []string {
+	return []string{}
+}
+
+func (tA testAuth) SetScopes(s []string) {}
+
+func TestSetHeaderRule(t *testing.T) {
+	t.Run("Should set header value from auth claim", func(t *testing.T) {
+		ht, err := NewHeaderPropagation(&config.HeaderRules{
+			All: &config.GlobalHeaderRule{
+				Request: []*config.RequestHeaderRule{
+					{
+						Operation: "set",
+						Name:      "X-Test-Auth-SomeClaim",
+						ValueFrom: &config.CustomDynamicAttribute{
+							AuthClaim: "some_claim",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		auth := &testAuth{
+			authenticator: "Some Authenticator",
+			claims: authentication.Claims{
+				"some_claim": "someClaimValue",
+			},
+		}
+		originReq = originReq.WithContext(withRequestContext(originReq.Context(), &requestContext{
+			request: originReq.WithContext(authentication.NewContext(originReq.Context(), auth)),
+		}))
+
+		clientReq.Context()
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 1)
+		assert.Equal(t, "someClaimValue", updatedClientReq.Header.Get("X-Test-Auth-SomeClaim"))
+	})
+
+	t.Run("Should not set header value if auth claim not found", func(t *testing.T) {
+		ht, err := NewHeaderPropagation(&config.HeaderRules{
+			All: &config.GlobalHeaderRule{
+				Request: []*config.RequestHeaderRule{
+					{
+						Operation: "set",
+						Name:      "X-Test-Auth-SomeClaim",
+						ValueFrom: &config.CustomDynamicAttribute{
+							AuthClaim: "some_claim",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		auth := &testAuth{
+			authenticator: "Some Authenticator",
+			claims: authentication.Claims{
+				"some_other_claim": "someOtherClaimValue",
+			},
+		}
+		originReq = originReq.WithContext(withRequestContext(originReq.Context(), &requestContext{
+			request: originReq.WithContext(authentication.NewContext(originReq.Context(), auth)),
+		}))
+
+		clientReq.Context()
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 0)
+	})
+
+	t.Run("Should not set header value if no auth context", func(t *testing.T) {
+		ht, err := NewHeaderPropagation(&config.HeaderRules{
+			All: &config.GlobalHeaderRule{
+				Request: []*config.RequestHeaderRule{
+					{
+						Operation: "set",
+						Name:      "X-Test-Auth-SomeClaim",
+						ValueFrom: &config.CustomDynamicAttribute{
+							AuthClaim: "some_claim",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		clientReq.Context()
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 0)
+	})
 }

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -33,6 +33,7 @@ type CustomDynamicAttribute struct {
 	RequestHeader  string `yaml:"request_header,omitempty"`
 	ContextField   string `yaml:"context_field,omitempty"`
 	ResponseHeader string `yaml:"response_header,omitempty"`
+	AuthClaim      string `yaml:"auth_claim,omitempty"`
 }
 
 type CustomAttribute struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -824,7 +824,15 @@
                       "context_field": {
                         "type": "string",
                         "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",
-                        "enum": ["operation_service_names", "graphql_error_codes", "graphql_error_service_names", "operation_sha256", "operation_name", "operation_hash", "router_config_version"]
+                        "enum": [
+                          "operation_service_names",
+                          "graphql_error_codes",
+                          "graphql_error_service_names",
+                          "operation_sha256",
+                          "operation_name",
+                          "operation_hash",
+                          "router_config_version"
+                        ]
                       }
                     }
                   }
@@ -851,14 +859,14 @@
                   "default": false,
                   "description": "Enable the collection of metrics for the GraphQL operation router caches. The default value is false."
                 },
-                "engine_stats" : {
+                "engine_stats": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
                     "subscriptions": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Enabling this will report additional engine metrics for WebSockets and SSE such as connections, subscriptions and triggers. The default value is false"
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enabling this will report additional engine metrics for WebSockets and SSE such as connections, subscriptions and triggers. The default value is false"
                     }
                   }
                 },
@@ -946,7 +954,7 @@
                   "default": false,
                   "description": "Enable the collection of metrics for the GraphQL operation router caches. The default value is false."
                 },
-                "engine_stats" : {
+                "engine_stats": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
@@ -2429,12 +2437,16 @@
           "type": "object",
           "description": "The configuration for the value from. The value from is used to extract a value from a request context and propagate it to subgraphs. This is currently only valid in requests",
           "additionalProperties": false,
-          "required": ["context_field"],
+          "oneOf": [{ "required": ["context_field"] }, { "required": ["auth_claim"] }],
           "properties": {
             "context_field": {
               "type": "string",
               "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",
               "enum": ["operation_name"]
+            },
+            "auth_claim": {
+              "type": "string",
+              "description": "The name of a claim from an authorized JWT from which to extract the value. The value is only extracted when a context is available otherwise the default value is used."
             }
           }
         }

--- a/router/pkg/config/json_schema.go
+++ b/router/pkg/config/json_schema.go
@@ -5,10 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dustin/go-humanize"
-	"github.com/goccy/go-yaml"
-	"github.com/santhosh-tekuri/jsonschema/v6"
-	"golang.org/x/text/message"
 	"io/fs"
 	"log"
 	"net"
@@ -19,6 +15,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/goccy/go-yaml"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"golang.org/x/text/message"
 )
 
 const (
@@ -332,12 +333,12 @@ func ValidateConfig(yamlData []byte, schema []byte) error {
 	c.RegisterVocabulary(goDurationVocab())
 	c.RegisterVocabulary(humanBytesVocab())
 
-	err = c.AddResource("https://raw.githubusercontent.com/wundergraph/cosmo/main/router/pkg/config/config.schema.json", s)
+	err = c.AddResource("https://raw.githubusercontent.com/cabiri-io/cosmo/main/router/pkg/config/config.schema.json", s)
 	if err != nil {
 		return err
 	}
 
-	sch, err := c.Compile("https://raw.githubusercontent.com/wundergraph/cosmo/main/router/pkg/config/config.schema.json")
+	sch, err := c.Compile("https://raw.githubusercontent.com/cabiri-io/cosmo/main/router/pkg/config/config.schema.json")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds capability to set headers in requests to the subgraphs, where the header values are derived from claims in the request context which have come from a verified authorization token.

Example configuration which would be used in `config.yaml`:

```
authentication:
  providers:
    - name: Some Auth Provider
      jwks:
        url: <some auth provder JWKS>
        refresh_interval: 5m

headers:
  all:
    request:
      - op: 'propagate'
        matching: Authorization
      - op: 'set'
        name: 'X-Authorization-Subject'
        value_from:
          auth_claim: sub
```

This would result in all requests to downstream subgraphs including a header `X-Authorization-Subject` where the value is the `sub` claim of an `Authorization` token which was verified with `Some Auth Provider`.

Also bumps `aws-lambda-router` version to `0.3.0`.