### PR TITLE
fix: add missing nil-check for authZ context

### DIFF
--- a/aws-lambda-router/package.json
+++ b/aws-lambda-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-router",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Placeholder package to simplify versioning and releasing with lerna.",
   "keywords": [

--- a/router/core/header_rule_engine_test.go
+++ b/router/core/header_rule_engine_test.go
@@ -1007,6 +1007,10 @@ func TestSetHeaderRule(t *testing.T) {
 		originReq, err := http.NewRequest("POST", "http://localhost", nil)
 		assert.Nil(t, err)
 
+		originReq = originReq.WithContext(withRequestContext(originReq.Context(), &requestContext{
+			request: originReq.WithContext(authentication.NewContext(originReq.Context(), nil)),
+		}))
+
 		clientReq.Context()
 
 		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{

--- a/router/core/request_context_fields.go
+++ b/router/core/request_context_fields.go
@@ -166,7 +166,7 @@ func getCustomDynamicAttributeValue(attribute *config.CustomDynamicAttribute, re
 		return reqContext.graphQLErrorCodes
 	}
 
-	if attribute.AuthClaim != "" {
+	if attribute.AuthClaim != "" && reqContext.Authentication() != nil {
 		claimVal := reqContext.Authentication().Claims()[attribute.AuthClaim]
 		if claimVal != nil {
 			return claimVal


### PR DESCRIPTION
Following #4, requests without an `Authorization: Bearer ...` header were throwing errors due to a missing nil check. This wasn't caught before because the unit test wasn't accurately replicating the state of the request context in such a situation.