### PR TITLE
feat: access logs for aws-lambda-router

### DIFF
--- a/aws-lambda-router/package.json
+++ b/aws-lambda-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-router",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Placeholder package to simplify versioning and releasing with lerna.",
   "keywords": [


### PR DESCRIPTION
Adds support for access logs into `aws-lambda-router`.

This was another instance of missing configuration handlers. Implementation lifted from:
https://github.com/cabiri-io/cosmo/blob/3838b9b06052acf33dd83b3ae4ee09e2946c7741/router/cmd/instance.go#L183